### PR TITLE
Various updates from working with Brad

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,41 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/dmacvicar/libvirt" {
+  version     = "0.7.1"
+  constraints = ">= 0.7.0"
+  hashes = [
+    "h1:ZG+KVAKVm++wfWnGdc8QIFn1LHRycUnmYibMg4REQyk=",
+    "zh:1c59f2ab68da6326637ee8b03433e84af76b3e3562f251a7f2aa239a7b262a8d",
+    "zh:236e24ecf036e99d9d1e2081a39dc9cb4b8993850a37141a1449f20750f883d6",
+    "zh:4519c22b1f00c1d37d60ac6c2cb7ad5ab9dbcd44a80b4f61e68aacb54eae017d",
+    "zh:54de4e3c979c32af1dc71ec2846912f669a28bdb0990e8a3c1fb8fea4ede7b61",
+    "zh:6270a757bcf4e1f9efe47726cf0caefba30a25e59d151103cf03d1656325783c",
+    "zh:68b8586d5b29c0a1cb7c608a309b38db911449c072d60eee9e40e01881f1c23a",
+    "zh:724ba2290fea704714378e9363541420c36091e790c7f39150cde8987d4e0754",
+    "zh:7b6860c92376cdad98273aab4bea62546622e08f50733e4b2e58a7a859d3b49d",
+    "zh:986a0a4f8d9511c64bcac8010337deb43110b4c2f91969b2491fd9edc290b60e",
+    "zh:aff0f6f24d69cd97a44cd6059edaf355769fbb8a7643a6db4d52c9a94f98e194",
+    "zh:c46ca3f8384d06c13a7ed3d4b83c65b4f8dccbf9d5f624843b68d176add5c5c2",
+    "zh:ef310534e7d38153aca4ce31655b52a6e6c4d76f32e49732c96b62e9de1ee843",
+    "zh:f1566b094f4267ef2674889d874962dd41e0cba55251645e16d003c77ca8a19c",
+    "zh:f2e019df7b537069828c5537c481e5b7f41d2404eef6fe5c86702c20900b303d",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/template" {
+  version = "2.2.0"
+  hashes = [
+    "h1:0wlehNaxBX7GJQnPfQwTNvvAf38Jm0Nv7ssKGMaG6Og=",
+    "zh:01702196f0a0492ec07917db7aaa595843d8f171dc195f4c988d2ffca2a06386",
+    "zh:09aae3da826ba3d7df69efeb25d146a1de0d03e951d35019a0f80e4f58c89b53",
+    "zh:09ba83c0625b6fe0a954da6fbd0c355ac0b7f07f86c91a2a97849140fea49603",
+    "zh:0e3a6c8e16f17f19010accd0844187d524580d9fdb0731f675ffcf4afba03d16",
+    "zh:45f2c594b6f2f34ea663704cc72048b212fe7d16fb4cfd959365fa997228a776",
+    "zh:77ea3e5a0446784d77114b5e851c970a3dde1e08fa6de38210b8385d7605d451",
+    "zh:8a154388f3708e3df5a69122a23bdfaf760a523788a5081976b3d5616f7d30ae",
+    "zh:992843002f2db5a11e626b3fc23dc0c87ad3729b3b3cff08e32ffb3df97edbde",
+    "zh:ad906f4cebd3ec5e43d5cd6dc8f4c5c9cc3b33d2243c89c5fc18f97f7277b51d",
+    "zh:c979425ddb256511137ecd093e23283234da0154b7fa8b21c2687182d9aea8b2",
+  ]
+}

--- a/dev.auto.tfvars
+++ b/dev.auto.tfvars
@@ -21,5 +21,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-interfaces = ["eth0"]
-volume_uri = "/vms/images/kubernetes-vm"
+interfaces  = ["eth0"]
+libvirt_uri = "qemu:///system"
+volume_uri  = "/vms/images/kubernetes-vm"
+volume_arch = "x86_64"

--- a/dev.local.tfvars
+++ b/dev.local.tfvars
@@ -21,6 +21,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-output "ip" {
-  value = libvirt_domain.main.network_interface
-}
+interfaces  = ["eth0"]
+libvirt_uri = "qemu:///system"
+volume_uri  = "../node-images/output-kubernetes-vm-qemu/kubernetes-vm"
+volume_arch = "x86_64"

--- a/docs/modules/development/pages/kubernetes.adoc
+++ b/docs/modules/development/pages/kubernetes.adoc
@@ -7,9 +7,16 @@ By default, the development variables in `dev.auto.tfvars` will load.
 These should be customized by the developer if their defaults are insufficient.
 
 NOTE: To load production variables, use `--var-file ./prod.tfvars`.
-Production variables will cater to expectations (such as interfaces) from a Fawkes hypervisor server..
+Production variables will cater to expectations (such as interfaces) from a Fawkes hypervisor server. In most cases, `./staging.tfvars` is sufficient for emulating `prod.tfvars`.
 
-== Local Development on a workstation
+== `.tfvars`
+
+`dev.auto.tfvars`:: The default variables, for a local hypervisor host (such as a VM).
+`dev.local.tfvars`:: Another development environment for local builds. This environment expects images to exist in a cloned node-images repository that neighbors this repository.
+`prod.test.tfvars`:: A staging environment that uses production variables, but instead of pulling images from Nexus it pulls them from the web server on the management VM. This expedites testing, the developer does not need to upload their images to nexus before running `terraform apply`.
+`prod.tfvars`:: Production environment, expects the images to exist in Nexus and the target hypervisors to be configured with all of their interfaces.
+
+== Local Development on a virtual machine or standalone host
 
 === Prerequisites
 
@@ -19,6 +26,22 @@ Production variables will cater to expectations (such as interfaces) from a Fawk
 
 === Launching VMs
 
+. Copy images into `/vms/images`
++
+[source,bash]
+----
+mkdir -p /vms/images
+scp remote-server:/my/folder/kubernetes-aa31de1-1694050687315-x86_64.qcow2 /vms/images/
+ln -snf ./kubernetes-aa31de1-1694050687315-x86_64.qcow2 /vms/images/kubernetes-x86_64.qcow2
+----
++
+Looks like:
++
+[source,bash]
+----
+/vms/images/kubernetes-aa31de1-1694050687315-x86_64.qcow2
+/vms/images/kubernetes-x86_64.qcow2 -> ./kubernetes-aa31de1-1694050687315-x86_64.qcow2
+----
 . Initialize Terraform
 +
 [source,bash]
@@ -32,7 +55,7 @@ terraform init
 terraform plan
 ----
 
-== Deployment on a Fawkes System
+== Test deployment on a Fawkes System
 
 === Prerequisites
 
@@ -40,7 +63,22 @@ terraform plan
 
 === Launching VMs
 
-. Change into the Terraform root, there should be an existing `.terraform` folder already so `terraform init` is not necessary
+. Place the VM images in `/var/www`, and point a symbolic link at it.
++
+[source,bash]
+----
+scp remote-server:/my/folder/kubernetes-aa31de1-1694050687315-x86_64.qcow2 /var/www
+ln -snf ./kubernetes-aa31de1-1694050687315-x86_64.qcow2 /var/www/kubernetes-x86_64.qcow2
+----
++
+Looks like:
++
+[source,bash]
+----
+/var/www/kubernetes-aa31de1-1694050687315-x86_64.qcow2
+/var/www/kubernetes-x86_64.qcow2 -> ./kubernetes-aa31de1-1694050687315-x86_64.qcow2
+----
+. Change into the Terraform root, there should be an existing `.terraform` folder already so `terraform init` is not necessary.
 +
 [source,bash]
 ----
@@ -50,5 +88,5 @@ cd /srv/cray/terraform
 +
 [source,bash]
 ----
-terraform plan -var-file="prod.tfvars"
+terraform plan -var-file="prod.test.tfvars"
 ----

--- a/modules/kubernetes/main.tf
+++ b/modules/kubernetes/main.tf
@@ -30,10 +30,6 @@ terraform {
   }
 }
 
-provider "libvirt" {
-  uri = "qemu:///system"
-}
-
 resource "libvirt_domain" "main" {
   name       = var.vm_name
   memory     = var.memory
@@ -41,7 +37,7 @@ resource "libvirt_domain" "main" {
   autostart  = true
   qemu_agent = true
 
-  cloudinit = libvirt_cloudinit_disk.common-init.id
+  cloudinit = libvirt_cloudinit_disk.commoninit.id
 
   dynamic "network_interface" {
     for_each = var.interfaces
@@ -58,6 +54,12 @@ resource "libvirt_domain" "main" {
     type        = "pty"
     target_type = "serial"
     target_port = "0"
+  }
+
+  console {
+    type        = "pty"
+    target_type = "virtio"
+    target_port = "1"
   }
 
   graphics {

--- a/modules/kubernetes/storage.tf
+++ b/modules/kubernetes/storage.tf
@@ -42,12 +42,22 @@ resource "libvirt_volume" "volume" {
   format         = var.volume_format
 }
 
-resource "libvirt_cloudinit_disk" "common-init" {
-  name      = format("${var.vm_name}_init.iso")
-  pool      = libvirt_pool.base-pool-name.name
-  user_data = data.template_file.user_data.rendered
+resource "libvirt_cloudinit_disk" "commoninit" {
+  name           = format("${var.vm_name}_init.iso")
+  pool           = libvirt_pool.base-pool-name.name
+  meta_data      = data.template_file.meta_data.rendered
+  network_config = data.template_file.network_config.rendered
+  user_data      = data.template_file.user_data.rendered
+}
+
+data "template_file" "meta_data" {
+  template = file("${path.module}/templates/meta-data.yml")
+}
+
+data "template_file" "network_config" {
+  template = file("${path.module}/templates/network-config.yml")
 }
 
 data "template_file" "user_data" {
-  template = file("${path.module}/templates/cloud-init.cfg")
+  template = file("${path.module}/templates/user-data.yml")
 }

--- a/modules/kubernetes/templates/meta-data.yml
+++ b/modules/kubernetes/templates/meta-data.yml
@@ -1,0 +1,3 @@
+---
+instance-id: kubernetes
+local-hostname: kubernetes

--- a/modules/kubernetes/templates/network-config.yml
+++ b/modules/kubernetes/templates/network-config.yml
@@ -1,0 +1,16 @@
+---
+network:
+  version: 2
+  ethernets:
+    eth0:
+      dhcp4: true
+      dhcp6: false
+      mtu: 9000
+    eth1:
+      dhcp4: true
+      dhcp6: false
+      mtu: 9000
+    eth2:
+      dhcp4: false
+      dhcp6: false
+      mtu: 9000

--- a/modules/kubernetes/templates/user-data.yml
+++ b/modules/kubernetes/templates/user-data.yml
@@ -1,4 +1,5 @@
 #cloud-config
+---
 users:
   - name: root
     ssh_authorized_keys: [ ]

--- a/modules/kubernetes/variables.tf
+++ b/modules/kubernetes/variables.tf
@@ -82,3 +82,8 @@ variable "interfaces" {
   description = "List of host interfaces that will the VM will receive a macvtap interface for"
   type        = list(string)
 }
+
+variable "libvirt_uri" {
+  description = "QEMU System URI"
+  type        = string
+}

--- a/prod.test.tfvars
+++ b/prod.test.tfvars
@@ -21,32 +21,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-terraform {
-  required_providers {
-    libvirt = {
-      source  = "dmacvicar/libvirt"
-      version = ">= 0.7.0"
-    }
-  }
-}
-
-provider "libvirt" {
-  alias = "k8s-worker"
-  uri   = var.libvirt_uri
-}
-
-module "kubernetes-worker" {
-  source        = "./modules/kubernetes"
-  vm_name       = "k8s-vm-worker"
-  pool          = "kubernetes-vm"
-  interfaces    = var.interfaces
-  volume_arch   = var.volume_arch
-  volume_uri    = var.volume_uri
-  volume_format = var.volume_format
-  libvirt_uri   = var.libvirt_uri
-  system_volume = 100
-  providers     = {
-    libvirt = libvirt.k8s-worker
-  }
-}
-
+interfaces  = ["bond0.nmn0", "bond0.hmn0", "bond0.cmn0"]
+libvirt_uri = "qemu+ssh://root@hypervisor/system?keyfile=/root/.ssh/id_ed25519"
+volume_uri  = "http://bootserver/kubernetes-vm"
+volume_arch = "x86_64"

--- a/prod.tfvars
+++ b/prod.tfvars
@@ -21,5 +21,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-interfaces = ["bond0.nmn0", "bond0.hmn0", "bond0.cmn0"]
-volume_uri = "http://bootserver/nexus/repository/os-images/kubernetes-vm"
+interfaces  = ["bond0.nmn0", "bond0.hmn0", "bond0.cmn0"]
+libvirt_uri = "qemu+ssh://root@hypervisor/system?keyfile=/root/.ssh/id_ed25519"
+volume_uri  = "http://bootserver/nexus/repository/os-images/kubernetes-vm"
+volume_arch = "x86_64"

--- a/variables.tf
+++ b/variables.tf
@@ -43,3 +43,8 @@ variable "volume_uri" {
   description = "URI to volumes (without the file extension)"
   type        = string
 }
+
+variable "libvirt_uri" {
+  description = "QEMU System URI"
+  type        = string
+}


### PR DESCRIPTION
- Adds `network-config` and `meta-data` to the cloud-init disk
- Adds a `prod.test.tfvars` that serves as a staging/production version of `prod.tfvars`
- Makes a `libvirt_uri` variable, allowing each `.tfvars` to set its own provider. This will be more helpful later, for now it's helpful for dev vs. staging/prod by using the local `qemu` or `ncn-h001`'s qemu
- Renames `common-init` back to `commoninit` because it matches online examples
- Adds `.terraform.lock.hcl` since it seems important for terraform init to always be the same.
