### PR TITLE
Align production volume sizes

### DIFF
--- a/prod/inventory.yaml
+++ b/prod/inventory.yaml
@@ -6,7 +6,7 @@ hypervisor_defaults: {}
 storage_pools_defaults:
   pool:
     name: default
-    prefix: /var/lib/libvirt
+    prefix: /vms/storeA/pools
 
 # This needs to match the roles
 volumes_defaults:
@@ -21,21 +21,21 @@ volumes_defaults:
       label: root
     - name: containerd
       mount: /var/lib/containerd
-      size: 100
+      size: 160
       wwn: 3000000000a1eead
       initialize: true
       fs_type: xfs
       label: CONLIB
     - name: run-containerd
       mount: /run/containerd
-      size: 100
+      size: 25
       wwn: 300000c0e1a1eead
       initialize: true
       fs_type: xfs
       label: CONRUN
     - name: kubelet
       mount: /var/lib/kubelet
-      size: 10
+      size: 40
       wwn: 300000000c0be1e1
       initialize: true
       fs_type: xfs
@@ -50,7 +50,7 @@ volumes_defaults:
       label: ETCDK8S
       pool:
         name: etcd
-        prefix: /var/lib/etcd
+        prefix: /vms/store0/pools
       luks:
         key: luks-etcd
   worker:
@@ -62,27 +62,39 @@ volumes_defaults:
       use_base_volume: true
       fs_type: xfs
       label: root
+      pool:
+        name: ephemeral
+        prefix: /vms/store0/pools
     - name: containerd
       mount: /var/lib/containerd
-      size: 100
+      size: 650
       wwn: 3000000000a1eead
       initialize: true
       fs_type: xfs
       label: CONLIB
+      pool:
+        name: ephemeral
+        prefix: /vms/store0/pools
     - name: run-containerd
       mount: /run/containerd
-      size: 100
+      size: 75
       wwn: 300000c0e1a1eead
       initialize: true
       fs_type: xfs
       label: CONRUN
+      pool:
+        name: ephemeral
+        prefix: /vms/store0/pools
     - name: kubelet
       mount: /var/lib/kubelet
-      size: 10
+      size: 40
       wwn: 300000000c0be1e1
       initialize: true
       fs_type: xfs
       label: K8SLET
+      pool:
+        name: ephemeral
+        prefix: /vms/store0/pools
 
 node_defaults:
   vcpu: 4

--- a/prod/inventory.yaml
+++ b/prod/inventory.yaml
@@ -113,7 +113,7 @@ volumes_defaults:
         name: ephemeral
         prefix: /vms/store0/pools
 node_defaults:
-  vcpu: 4
+  vcpu: 8
   memory: 16384
   interfaces:
     - bond0.nmn0

--- a/prod/inventory.yaml
+++ b/prod/inventory.yaml
@@ -40,6 +40,13 @@ volumes_defaults:
       initialize: true
       fs_type: xfs
       label: K8SLET
+    - name: s3fs_cache
+      mount: /var/lib/s3fs_cache
+      size: 100
+      wwn: 30000000000cac1e
+      initialize: true
+      fs_type: xfs
+      label: S3FS
   etcd:
     - name: etcd
       mount: /var/lib/etcd
@@ -95,7 +102,16 @@ volumes_defaults:
       pool:
         name: ephemeral
         prefix: /vms/store0/pools
-
+    - name: s3fs_cache
+      mount: /var/lib/s3fs_cache
+      size:
+      wwn: 30000000000cac1e
+      initialize: true
+      fs_type: xfs
+      label: S3FS
+      pool:
+        name: ephemeral
+        prefix: /vms/store0/pools
 node_defaults:
   vcpu: 4
   memory: 16384


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
This does a few things:
- Aligns volume sizes with https://rndwiki-pro.its.hpecorp.net/display/CSMTemp/Disk+Layout+-+Hypervisor+Partitions+and+VM+Virtual+Disks
- Doubles the CPUs used by VMs from 4 to 8 for production, this will provide more sandbox resources until we dynamically figure this out
- Adds `s3fs_cache` to production only. This volume is not necessary for dev, it takes up extra space.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
