### PR TITLE
DRAFT: pci-mapping-support

### DIFF
--- a/dev/inventory/defaults.yaml
+++ b/dev/inventory/defaults.yaml
@@ -16,10 +16,6 @@ storage_pools_defaults:
     name: default
     prefix: /var/lib/libvirt
 
-luks_keys:
-  luks-etcd:
-    filename: /etc/pki/luks-etcd.key
-
 # this needs to match the VM roles
 volumes_defaults:
   master:

--- a/dev/inventory/hypervisors.yaml
+++ b/dev/inventory/hypervisors.yaml
@@ -1,8 +1,8 @@
-
 hypervisors:
   h001:
     vms:
       v001:
+        pci_passthrough: true
         roles:
         - master
         - etcd

--- a/dev/inventory/hypervisors/h001.yaml
+++ b/dev/inventory/hypervisors/h001.yaml
@@ -1,0 +1,18 @@
+h001:
+  pci_mapping:
+  - bus: '0x81'
+    domain: '0x0000'
+    function: '0x0'
+    slot: '0x00'
+  - bus: '0x81'
+    domain: '0x0000'
+    function: '0x1'
+    slot: '0x00'
+  - bus: '0xda'
+    domain: '0x0000'
+    function: '0x0'
+    slot: '0x00'
+  - bus: '0xda'
+    domain: '0x0000'
+    function: '0x1'
+    slot: '0x00'

--- a/dev/inventory/luks_keys.yaml
+++ b/dev/inventory/luks_keys.yaml
@@ -1,0 +1,3 @@
+luks_keys:
+  luks-etcd:
+    filename: /etc/pki/luks-etcd.key

--- a/modules/kubernetes/main.tf
+++ b/modules/kubernetes/main.tf
@@ -140,4 +140,10 @@ resource "libvirt_domain" "vm" {
     autoport    = true
   }
 
+  dynamic "xml" {
+    for_each = length(var.pci_mapping) > 0 ? ["1"] : []
+    content {
+      xslt = templatefile("${path.module}/templates/domain-xslt.xml.tpl", { pci_data = var.pci_mapping } )
+    }
+  }
 }

--- a/modules/kubernetes/templates/domain-xslt.xml.tpl
+++ b/modules/kubernetes/templates/domain-xslt.xml.tpl
@@ -1,0 +1,23 @@
+<?xml version="1.0" ?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output omit-xml-declaration="yes" indent="yes"/>
+  <xsl:template match="node()|@*">
+    <xsl:copy>
+      <xsl:apply-templates select="node()|@*"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <xsl:template match="/domain/devices">
+    <xsl:copy>
+      <xsl:apply-templates select="@* | node()"/>
+        %{~ for item in pci_data ~}
+        <hostdev mode='subsystem' type='pci' managed='yes'>
+          <driver name='vfio'/>
+            <source>
+              <address type="pci" domain="${item.domain}" bus="${item.bus}" slot="${item.slot}" function="${item.function}"/>
+            </source>
+        </hostdev>
+        %{~ endfor ~}
+    </xsl:copy>
+  </xsl:template>
+</xsl:stylesheet>

--- a/modules/kubernetes/variables.tf
+++ b/modules/kubernetes/variables.tf
@@ -98,3 +98,8 @@ variable "ssh_keys" {
   type = list(string)
   default = []
 }
+
+variable "pci_mapping" {
+  type = list(any)
+  default = []
+}


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes:
- Requires:
- Relates to: Support PCI mapping of devices from Hypervisors.

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request
- Docs Pull Request
- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
### Details

Please review for now, maybe more changes are needed.

Changes revolve around changing the inventory system to load hypervisor specific configurations from a separate folder `inventory/hypervisors` which then will be patched/merged directly into the local.hypervisors.<name> tree. This allows us to have a per-hypervisor PCI mapping list, which in turn, depending on the vm.pci_passthrough boolean, will populate the pci_mapping list with pci_mapping from the hypervisor.
In the end this generates the xslt that patches in pci mapping (since it is not supported by libvirt directly).
The template supports _only_ pci mapping via VFIO. There's no support for VF or other parameters that mercury set (disk/volume caching, etc).

Needless to day, the pci_mapping data is placeholder, it is from a real system but it will not be useful on a dev machine.